### PR TITLE
Update $packageVersionID from String! to ID!

### DIFF
--- a/src/strategy/strategy.js
+++ b/src/strategy/strategy.js
@@ -5,7 +5,7 @@ const DEFAULT_VERSION_PATTERN = /^.+$/
 const DEFAULT_KEEP = 2
 
 const deleteMutation = `
-  mutation deletePackageVersion($packageVersionId: String!) {
+  mutation deletePackageVersion($packageVersionId: ID!) {
     deletePackageVersion(input: {packageVersionId: $packageVersionId}) {
       success
     }


### PR DESCRIPTION
Resolves #19 

`DeletePackageVersionInput` seems to have changed from `String!` to `ID!` for `packageVersionId`:
https://docs.github.com/en/graphql/reference/input-objects#deletepackageversioninput

Can't find the change in the Github API changelog though to confirm.

The `ID` [scalar](https://docs.github.com/en/graphql/reference/scalars#id) should match the shape of what's being sent through, and no need to change the response since docs claim it's returned as a string